### PR TITLE
Ensure check_ror_id() returns the successful ROR ID candidate

### DIFF
--- a/rorapi/management/commands/generaterorid.py
+++ b/rorapi/management/commands/generaterorid.py
@@ -29,6 +29,6 @@ def check_ror_id():
                             '_id': ror_id
                             }}})
     if s['hits']['total'] == 1 or s in GRID_REMOVED_IDS:
-        check_ror_id()
+        return check_ror_id()
     return ror_id
 


### PR DESCRIPTION
Currently, if the check_ror_id() function recurses, it eventually generates a unique ROR ID, but fails to return it: it returns the first unsuccessful one instead.